### PR TITLE
Fixed recursive use of make in makefiles [ make -> $(MAKE) ]

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -830,7 +830,7 @@ $(top_builddir)/src/libcommon/libcommon.la \
 $(top_builddir)/src/libmissing/libmissing.la \
 $(top_builddir)/src/libmunge/libmunge.la \
 : force-dependency-check
-	@cd `dirname $@` && make `basename $@`
+	@cd `dirname $@` && $(MAKE) `basename $@`
 
 force-dependency-check:
 

--- a/config/Make-inc.mk
+++ b/config/Make-inc.mk
@@ -31,7 +31,7 @@ $(top_builddir)/src/libcommon/libcommon.la \
 $(top_builddir)/src/libmissing/libmissing.la \
 $(top_builddir)/src/libmunge/libmunge.la \
 : force-dependency-check
-	@cd `dirname $@` && make `basename $@`
+	@cd `dirname $@` && $(MAKE) `basename $@`
 
 force-dependency-check:
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -648,7 +648,7 @@ $(top_builddir)/src/libcommon/libcommon.la \
 $(top_builddir)/src/libmissing/libmissing.la \
 $(top_builddir)/src/libmunge/libmunge.la \
 : force-dependency-check
-	@cd `dirname $@` && make `basename $@`
+	@cd `dirname $@` && $(MAKE) `basename $@`
 
 force-dependency-check:
 

--- a/src/etc/Makefile.in
+++ b/src/etc/Makefile.in
@@ -451,7 +451,7 @@ $(top_builddir)/src/libcommon/libcommon.la \
 $(top_builddir)/src/libmissing/libmissing.la \
 $(top_builddir)/src/libmunge/libmunge.la \
 : force-dependency-check
-	@cd `dirname $@` && make `basename $@`
+	@cd `dirname $@` && $(MAKE) `basename $@`
 
 force-dependency-check:
 

--- a/src/libcommon/Makefile.in
+++ b/src/libcommon/Makefile.in
@@ -683,7 +683,7 @@ $(top_builddir)/src/libcommon/libcommon.la \
 $(top_builddir)/src/libmissing/libmissing.la \
 $(top_builddir)/src/libmunge/libmunge.la \
 : force-dependency-check
-	@cd `dirname $@` && make `basename $@`
+	@cd `dirname $@` && $(MAKE) `basename $@`
 
 force-dependency-check:
 

--- a/src/libmissing/Makefile.in
+++ b/src/libmissing/Makefile.in
@@ -572,7 +572,7 @@ $(top_builddir)/src/libcommon/libcommon.la \
 $(top_builddir)/src/libmissing/libmissing.la \
 $(top_builddir)/src/libmunge/libmunge.la \
 : force-dependency-check
-	@cd `dirname $@` && make `basename $@`
+	@cd `dirname $@` && $(MAKE) `basename $@`
 
 force-dependency-check:
 

--- a/src/libmunge/Makefile.in
+++ b/src/libmunge/Makefile.in
@@ -752,7 +752,7 @@ $(top_builddir)/src/libcommon/libcommon.la \
 $(top_builddir)/src/libmissing/libmissing.la \
 $(top_builddir)/src/libmunge/libmunge.la \
 : force-dependency-check
-	@cd `dirname $@` && make `basename $@`
+	@cd `dirname $@` && $(MAKE) `basename $@`
 
 force-dependency-check:
 

--- a/src/munge/Makefile.in
+++ b/src/munge/Makefile.in
@@ -752,7 +752,7 @@ $(top_builddir)/src/libcommon/libcommon.la \
 $(top_builddir)/src/libmissing/libmissing.la \
 $(top_builddir)/src/libmunge/libmunge.la \
 : force-dependency-check
-	@cd `dirname $@` && make `basename $@`
+	@cd `dirname $@` && $(MAKE) `basename $@`
 
 force-dependency-check:
 

--- a/src/munged/Makefile.in
+++ b/src/munged/Makefile.in
@@ -1243,7 +1243,7 @@ $(top_builddir)/src/libcommon/libcommon.la \
 $(top_builddir)/src/libmissing/libmissing.la \
 $(top_builddir)/src/libmunge/libmunge.la \
 : force-dependency-check
-	@cd `dirname $@` && make `basename $@`
+	@cd `dirname $@` && $(MAKE) `basename $@`
 
 force-dependency-check:
 


### PR DESCRIPTION
I have fixed the way the make command was been called in the makefiles.

Use "$(MAKE)" instead of just "make" when recursively calling make.
http://www.gnu.org/software/make/manual/make.html#Recursion