### PR TITLE
libmissing: rename libmissing symbols

### DIFF
--- a/src/libmissing/inet_ntop.h
+++ b/src/libmissing/inet_ntop.h
@@ -41,6 +41,9 @@
 #  include <arpa/inet.h>
 #else  /* !HAVE_INET_NTOP */
 #  include <sys/socket.h>
+
+#define inet_ntop libmissing_inet_ntop
+
 const char *inet_ntop (int af, const void *src, char *dst, socklen_t cnt);
 #endif /* !HAVE_INET_NTOP */
 

--- a/src/libmissing/strlcat.c
+++ b/src/libmissing/strlcat.c
@@ -23,6 +23,8 @@ static char *rcsid = "$OpenBSD: strlcat.c,v 1.11 2003/06/17 21:56:24 millert Exp
 #include <sys/types.h>
 #include <string.h>
 
+#include "missing.h"
+
 /*
  * Appends src to string dst of size siz (unlike strncat, siz is the
  * full size of dst, not space left).  At most siz-1 characters

--- a/src/libmissing/strlcat.h
+++ b/src/libmissing/strlcat.h
@@ -3,6 +3,9 @@
 #endif /* HAVE_CONFIG_H */
 
 #if !HAVE_STRLCAT
+
+#define strlcat libmissing_strlcat
+
 size_t strlcat(char *dst, const char *src, size_t siz);
 /*
  *  Appends src to string dst of size siz (unlike strncat, siz is the

--- a/src/libmissing/strlcpy.c
+++ b/src/libmissing/strlcpy.c
@@ -23,6 +23,8 @@ static char *rcsid = "$OpenBSD: strlcpy.c,v 1.8 2003/06/17 21:56:24 millert Exp 
 #include <sys/types.h>
 #include <string.h>
 
+#include "missing.h"
+
 /*
  * Copy src to string dst of size siz.  At most siz-1 characters
  * will be copied.  Always NUL terminates (unless siz == 0).

--- a/src/libmissing/strlcpy.h
+++ b/src/libmissing/strlcpy.h
@@ -3,6 +3,9 @@
 #endif /* HAVE_CONFIG_H */
 
 #if !HAVE_STRLCPY
+
+#define strlcpy libmissing_strlcpy
+
 size_t strlcpy(char *dst, const char *src, size_t siz);
 /*
  *  Copy src to string dst of size siz.  At most siz-1 characters


### PR DESCRIPTION
This commit renames the libmissing symbols to start with
libmissing. This will prevent conflicts with other libraries that may
also export these symbols.

Fixes #49

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>