### PR TITLE
Full- versus final-directory check option added to path_is_secure()

### DIFF
--- a/src/munged/auth_recv.h
+++ b/src/munged/auth_recv.h
@@ -32,9 +32,11 @@
 
 #include <sys/types.h>
 #include "m_msg.h"
+#include "path.h"
 
 
-void auth_recv_init (const char *srvrdir, const char *clntdir, int got_force);
+void auth_recv_init (const char *srvrdir, const char *clntdir, int got_force,
+          path_security_flag_t base_pathsec_server, path_security_flag_t base_pathsec_client);
 /*
  *  Checks for required privileges needed to perform client authentication.
  */

--- a/src/munged/conf.h
+++ b/src/munged/conf.h
@@ -40,6 +40,18 @@
  *  Data Types
  *****************************************************************************/
 
+enum pathsec_path_kind {
+  pathsec_path_kind_all                 = 0,
+  pathsec_path_kind_keyfile,
+  pathsec_path_kind_randomseed,
+  pathsec_path_kind_logfile,
+  pathsec_path_kind_pidfile,
+  pathsec_path_kind_socket,
+  pathsec_path_kind_server_dir,
+  pathsec_path_kind_client_dir,
+  pathsec_path_kind_max
+};
+
 struct conf {
     int             ld;                 /* listening socket descriptor       */
     unsigned        got_benchmark:1;    /* flag for BENCHMARK option         */
@@ -75,6 +87,11 @@ struct conf {
     char           *auth_server_dir;    /* dir in which to create auth pipe  */
     char           *auth_client_dir;    /* dir in which to create auth file  */
     int             auth_rnd_bytes;     /* num rnd bytes in auth pipe name   */
+                                        /* each specific kind of path for    
+                                         * path_is_secure can have a base
+                                         * strictness:
+                                         */
+    int             base_pathsec[pathsec_path_kind_max];
 };
 
 typedef struct conf * conf_t;

--- a/src/munged/munged.8.in
+++ b/src/munged/munged.8.in
@@ -134,6 +134,10 @@ Specify an alternate pathname for storing the Process ID of the daemon.
 .TP
 .BI "\-\-syslog"
 Redirect log messages to syslog when the daemon is running in the background.
+.TP
+.BI "\-\-pathsec " sec-list
+Specify the security level(s) to apply to security checks of specific paths used by \fBmunged\fR.  The list is comprised of one or more specifications of "kind:level" separated by commas.  The kind of path should be one of:  all, keyfile, randomseed, logfile, pidfile, socket, server_dir, client_dir.  The level can be strict (all directories must satisfy security criteria) or loose (only the final directory on the path must satisfy security criteria).  Omitting the "kind:" implies the all kind.
+For example, the sec-list "all:strict,keyfile:loose" requests strict security checks of all paths except that of the key file.
 
 .SH SIGNALS
 .TP

--- a/src/munged/path.c
+++ b/src/munged/path.c
@@ -229,6 +229,14 @@ path_is_secure (const char *path, char *errbuf, size_t errbuflen,
             return (_path_set_err (0, errbuf, errbuflen,
                 "world-writable permissions set on \"%s\"", buf));
         }
+
+        /* If the check is supposed to be against just the final directory on the
+         * path, then break out of the loop immediately:
+         */
+        if ( (flags & PATH_SECURITY_FINAL_DIR_ONLY) ) {
+            break;
+        }
+
         if (!(p = strrchr (buf, '/'))) {
             errno = EINVAL;
             return (_path_set_err (-1, errbuf, errbuflen,

--- a/src/munged/path.h
+++ b/src/munged/path.h
@@ -44,7 +44,8 @@
 
 typedef enum path_security_flags {
     PATH_SECURITY_NO_FLAGS =            0x00,
-    PATH_SECURITY_IGNORE_GROUP_WRITE =  0x01
+    PATH_SECURITY_IGNORE_GROUP_WRITE =  0x01,
+    PATH_SECURITY_FINAL_DIR_ONLY =      0x02
 } path_security_flag_t;
 
 

--- a/src/munged/random.c
+++ b/src/munged/random.c
@@ -97,7 +97,7 @@ void _random_seed_stir_callback (void *_arg_not_used_);
  *****************************************************************************/
 
 int
-random_init (const char *seed)
+random_init (const char *seed, path_security_flag_t base_pathsec)
 {
     int          rnd_bytes_needed       = RANDOM_SEED_BYTES;
     int          rc                     = 0;
@@ -149,7 +149,7 @@ random_init (const char *seed)
                 "Failed to determine dirname of PRNG seed \"%s\"", seed);
         }
         n = path_is_secure (seed_dir, ebuf, sizeof (ebuf),
-            PATH_SECURITY_NO_FLAGS);
+            PATH_SECURITY_NO_FLAGS | base_pathsec);
         if (n < 0) {
             log_err (EMUNGE_SNAFU, LOG_ERR,
                 "Failed to check PRNG seed dir \"%s\": %s", seed_dir, ebuf);

--- a/src/munged/random.h
+++ b/src/munged/random.h
@@ -29,8 +29,10 @@
 #ifndef RANDOM_H
 #define RANDOM_H
 
+#include "path.h"
 
-int random_init (const char *seed);
+
+int random_init (const char *seed, path_security_flag_t base_pathsec);
 /*
  *  Initializes the PRNG from the [seed] file.
  *  If [seed] does not exist or provide sufficient entropy,


### PR DESCRIPTION
The path_is_secure() function currently checks every directory in a path for satisfaction of the security requirements (ownership, privileges).  While the "--force" flag to munged causes it to not exit if the checks are not satisfied, a finer degree of control seemed like it might be useful.

A flag was added to the path_security_flag_t enumeration (path.h) to request that ONLY the final directory in the path given to path_is_secure() be tested against the criteria:  e.g. so long as the parent directory of the key file is secure the function returns boolean true.  This flag allows for "loose" security testing; sans this flag the program uses "strict" path testing.

The munged "conf" struct has been altered to allow for a global path security level as well as levels for each of the paths that are tested using path_is_secure().  Thus, while the default path security remains "strict" the sysadmin can specifically override the security for individual paths, e.g.

     munged --pathsec=keyfile:loose,logfile:loose ...

Builtin help updated with these additions, as well as the munged.8 man page.