### PR TITLE
Let systemd unit file use /etc/sysconfig/munge for munge options

### DIFF
--- a/src/etc/munge.service.in
+++ b/src/etc/munge.service.in
@@ -6,7 +6,8 @@ After=time-sync.target
 
 [Service]
 Type=forking
-ExecStart=@sbindir@/munged
+EnvironmentFile=-@sysconfdir@/sysconfig/munge
+ExecStart=@sbindir@/munged $DAEMON_ARGS
 PIDFile=@localstatedir@/run/munge/munged.pid
 User=munge
 Group=munge


### PR DESCRIPTION
Fixes #64 

This allows you to cleanly specify options to munged. No need to change a unit file.