### PR TITLE
Add a --hostname option

### DIFF
--- a/src/munged/conf.h
+++ b/src/munged/conf.h
@@ -77,6 +77,7 @@ struct conf {
     char           *auth_server_dir;    /* dir in which to create auth pipe  */
     char           *auth_client_dir;    /* dir in which to create auth file  */
     int             auth_rnd_bytes;     /* num rnd bytes in auth pipe name   */
+    char           *hostname;           /* which hostname to use for munged  */
 };
 
 typedef struct conf * conf_t;


### PR DESCRIPTION
This PR adds a option `--hostname` to munged which allows you to pick which hostname munged should use. It should be resolvable and a network interface of the host should have the ip.

I think it makes more sense to allow a hostname option than a network interface option because the latter can have multiple IPs assigned to it.