### PR TITLE
Added support for Linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ env:
   - CONFIGURE_OPTS="--disable-debug --with-crypto-lib=libgcrypt"
   - CONFIGURE_OPTS="--disable-debug --with-crypto-lib=openssl"
 
+arch:
+  - ppc64le
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Hi,
I had added ppc64le support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/munge/builds/182542152

Please have a look.

Regards,
ujjwal