### PR TITLE
add --listen-backlog option in munged

### DIFF
--- a/src/munged/conf.c
+++ b/src/munged/conf.c
@@ -415,11 +415,19 @@ parse_cmdline (conf_t conf, int argc, char **argv)
                 l = strtol (optarg, &p, 10);
                 if (((errno == ERANGE) && ((l == LONG_MIN) || (l == LONG_MAX)))
                         || (optarg == p) || (*p != '\0')
-                        || (l <= 0) || (l > INT_MAX)) {
+                        || (l < -1) || (l > INT_MAX)) {
                     log_err (EMUNGE_SNAFU, LOG_ERR,
                         "Invalid value \"%s\" for listen-backlog", optarg);
                 }
-                conf->listen_backlog = l;
+                else if (l == 0) {
+                    conf->listen_backlog = MUNGE_SOCKET_BACKLOG;
+                }
+                else if (l == -1) {
+                    conf->listen_backlog = SOMAXCONN;
+                }
+                else {
+                    conf->listen_backlog = l;
+                }
                 break;
             case OPT_LOG_FILE:
                 _conf_set_string (&conf->logfile_name, optarg, conf->cwd,

--- a/src/munged/conf.h
+++ b/src/munged/conf.h
@@ -65,6 +65,7 @@ struct conf {
     char           *logfile_name;       /* daemon logfile name               */
     char           *pidfile_name;       /* daemon pidfile name               */
     char           *socket_name;        /* unix domain socket filename       */
+    int             listen_backlog;     /* unix domain socket listen backlog */
     char           *seed_name;          /* random seed filename              */
     char           *key_name;           /* symmetric key filename            */
     unsigned char  *dek_key;            /* subkey for cipher ops             */

--- a/src/munged/munged.8.in
+++ b/src/munged/munged.8.in
@@ -132,7 +132,10 @@ triggered by a \fBSIGHUP\fR).  A value of \-1 causes it to be disabled.
 Specify an alternate pathname to the key file.
 .TP
 .BI "\-\-listen\-backlog " integer
-Specify an alternate listen backlog size of the local domain socket.
+Specify the socket's listen backlog limit; note that the kernel may impose
+a lower limit.  A value of 0 uses the software default.  A value of \-1
+specifies \fBSOMAXCONN\fR, the maximum listen backlog queue length defined
+in \fI<sys/socket.h>\fR.
 .TP
 .BI "\-\-log\-file " path
 Specify an alternate pathname to the log file.

--- a/src/munged/munged.8.in
+++ b/src/munged/munged.8.in
@@ -131,6 +131,9 @@ triggered by a \fBSIGHUP\fR).  A value of \-1 causes it to be disabled.
 .BI "\-\-key\-file " path
 Specify an alternate pathname to the key file.
 .TP
+.BI "\-\-listen\-backlog " integer
+Specify an alternate listen backlog size of the local domain socket.
+.TP
 .BI "\-\-log\-file " path
 Specify an alternate pathname to the log file.
 .TP

--- a/src/munged/munged.c
+++ b/src/munged/munged.c
@@ -670,12 +670,14 @@ sock_create (conf_t conf)
         log_errno (EMUNGE_SNAFU, LOG_ERR,
             "Failed to bind socket \"%s\"", conf->socket_name);
     }
-    if (listen (sd, MUNGE_SOCKET_BACKLOG) < 0) {
+    if (listen (sd, conf->listen_backlog) < 0) {
         log_errno (EMUNGE_SNAFU, LOG_ERR,
             "Failed to listen on socket \"%s\"", conf->socket_name);
     }
     conf->ld = sd;
     log_msg (LOG_INFO, "Created socket \"%s\"", conf->socket_name);
+    log_msg (LOG_INFO, "Set socket listen backlog to %d",
+            conf->listen_backlog);
     return;
 }
 


### PR DESCRIPTION
This small PR adds an option `--listen-backlog` for the `munged` service if the user wants to override the default domain socket backlog value.

If no option is passed, then `munged` would use the default value that `MUNGE_SOCKET_BACKLOG` is defined.

Thanks.
