### PR TITLE
Spec file correction affected rpm build

### DIFF
--- a/munge.spec.in
+++ b/munge.spec.in
@@ -153,7 +153,7 @@ systemd-tmpfiles --create %{_tmpfilesdir}/munge.conf
 %attr(0600,munge,munge) %ghost %{_localstatedir}/lib/munge/munged.seed
 %dir %attr(0700,munge,munge) %{_localstatedir}/log/munge
 %attr(0640,munge,munge) %ghost %{_localstatedir}/log/munge/munged.log
-%dir %attr(0755,munge,munge) %ghost %{_rundir}/munge
+%dir %attr(0755,munge,munge) %{_rundir}/munge
 %attr(0644,munge,munge) %ghost %{_rundir}/munge/munged.pid
 %{_bindir}/munge
 %{_bindir}/remunge

--- a/munge.spec.in
+++ b/munge.spec.in
@@ -91,6 +91,8 @@ sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 
 %install
 %make_install
+mkdir -p %{buildroot}%{_sysconfdir}/munge
+mkdir -p %{buildroot}%{_localstatedir}/(lib,log}/munge
 touch %{buildroot}%{_sysconfdir}/munge/munge.key
 touch %{buildroot}%{_localstatedir}/lib/munge/munged.seed
 touch %{buildroot}%{_localstatedir}/log/munge/munged.log


### PR DESCRIPTION
Spec file correction to provide rpm build without failure due to no folder existed and starting the daemon after build rpm installation with failure of no folder fo start socket.