### PR TITLE
logrotate.conf: drop privileges to munge user and group

### DIFF
--- a/src/etc/munge.logrotate.conf.in
+++ b/src/etc/munge.logrotate.conf.in
@@ -5,4 +5,5 @@
     compress
     nodelaycompress
     missingok
+    su munge munge
 }


### PR DESCRIPTION
Since the log directory is owned by the munge user and group, logrotate should drop privileges to these credentials as well, to minimize attack surface. Otherwise logrotate operates in this directory as root, potentially falling victim to symlink attacks and similar problems, should the munge user account be compromised.